### PR TITLE
[FIX] base_changeset: disable during loading

### DIFF
--- a/base_changeset/__init__.py
+++ b/base_changeset/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
+from . import common
 from . import models
+from .hooks import post_load

--- a/base_changeset/__manifest__.py
+++ b/base_changeset/__manifest__.py
@@ -25,4 +25,5 @@
     "demo": ["demo/changeset_field_rule.xml"],
     "qweb": ["static/src/xml/backend.xml"],
     "installable": True,
+    "post_load": "post_load",
 }

--- a/base_changeset/common.py
+++ b/base_changeset/common.py
@@ -1,0 +1,1 @@
+disable_changeset = object()

--- a/base_changeset/hooks.py
+++ b/base_changeset/hooks.py
@@ -1,0 +1,21 @@
+from odoo.tools.convert import xml_import
+
+from .common import disable_changeset
+
+orig_xml_import_get_env = xml_import.get_env
+
+
+def post_load():
+    """
+    Monkey patch the loading of XML module data.
+
+    Otherwise, existing rules may break the installation of other modules.
+    """
+
+    def get_env(self, node, eval_context=None):
+        env = orig_xml_import_get_env(self, node, eval_context=eval_context)
+        if "__no_changeset" not in env.context:
+            env = env(context=dict(**env.context, __no_changeset=disable_changeset))
+        return env
+
+    xml_import.get_env = get_env

--- a/base_changeset/models/base.py
+++ b/base_changeset/models/base.py
@@ -8,7 +8,7 @@ from odoo.tools import config
 
 # put this object into context key '__no_changeset' to disable changeset
 # functionality
-disable_changeset = object()
+from ..common import disable_changeset
 
 
 class Base(models.AbstractModel):

--- a/base_changeset/tests/test_changeset_flow.py
+++ b/base_changeset/tests/test_changeset_flow.py
@@ -8,7 +8,7 @@ from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
-from ..models.base import disable_changeset
+from ..common import disable_changeset
 from .common import ChangesetTestCommon
 
 

--- a/base_changeset/tests/test_changeset_origin.py
+++ b/base_changeset/tests/test_changeset_origin.py
@@ -4,7 +4,7 @@
 
 from odoo.tests.common import Form, TransactionCase
 
-from ..models.base import disable_changeset
+from ..common import disable_changeset
 from .common import ChangesetTestCommon
 
 


### PR DESCRIPTION
Don't create changesets when loading module data. Otherwise, existing rules
may break tests that depend on the data being loaded before manual validation.