### PR TITLE
[FIX] ERP-2315, take default company from env, not from user

### DIFF
--- a/base_changeset/models/record_changeset.py
+++ b/base_changeset/models/record_changeset.py
@@ -168,7 +168,7 @@ class RecordChangeset(models.Model):
     def _prepare_changeset_vals(self, changes, record, source):
         has_company = "company_id" in self.env[record._name]._fields
         has_company = has_company and record.company_id
-        company = record.company_id if has_company else self.env.user.company_id
+        company = record.company_id if has_company else self.env.company
         return {
             # newly created records are passed as newid records with the id in ref
             "res_id": record.id or record.id.ref,


### PR DESCRIPTION
The error was caused by a mistake of mine when I forward ported the security fixes from 12.0: https://github.com/EmesaDEV/server-tools/commit/9245f1a5d7b19307d53606385d233b82f70dca3b#diff-653e4273c0a87f2cc9b3d38b785b81e3733817977129c00a77b016a3ecc216adL153-R161

The security fixes are proposed upstream in unmerged https://github.com/OCA/server-tools/pull/2246. I squashed out the bug there as well.