### PR TITLE
[RFR] ERP-2593, base_changeset: no change for empty values on create

### DIFF
--- a/base_changeset/models/record_changeset.py
+++ b/base_changeset/models/record_changeset.py
@@ -133,7 +133,8 @@ class RecordChangeset(models.Model):
         )
         for field in values:
             rule = rules.get(field)
-            if not rule or not rule._evaluate_expression(record):
+            if not rule or not rule._evaluate_expression(record) or (
+                    create and not values[field]):
                 continue
             if field in values:
                 if not create and not change_model._has_field_changed(

--- a/base_changeset/tests/test_changeset_flow.py
+++ b/base_changeset/tests/test_changeset_flow.py
@@ -104,6 +104,34 @@ class TestChangesetFlow(ChangesetTestCommon, TransactionCase):
         self.assertFalse(new.street)
         self.assertFalse(new.street2)
 
+    def test_create_new_changeset_empty_value(self):
+        """ No change is created for empty values on create """
+        new = (
+            self.env["res.partner"]
+            .with_context(test_record_changeset=True)
+            .create(
+                {
+                    "name": "partner",
+                    "street": "street",
+                    "street2": False,
+                }
+            )
+        )
+        new._compute_changeset_ids()
+        new._compute_count_pending_changesets()
+        self.assertEqual(new.count_pending_changesets, 1)
+        self.assert_changeset(
+            new,
+            self.env.user,
+            [
+                (self.field_name, False, "partner", "done"),
+                (self.field_street, False, "street", "draft"),
+            ],
+        )
+        self.assertEqual(new.name, "partner")
+        self.assertFalse(new.street)
+        self.assertFalse(new.street2)
+
     def test_new_changeset_empty_value(self):
         """ Create a changeset change that empty a value """
         self.partner.write({"street": False})


### PR DESCRIPTION
Regression of earlier fix. Fixed upstream in last commit of https://github.com/OCA/server-tools/pull/2246