### PR TITLE
[IMP] Allow loading of auditlog rules from module definitions

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -232,9 +232,10 @@ class AuditlogRule(models.Model):
             model = self.env["ir.model"].sudo().browse(vals["model_id"])
             vals.update({"model_name": model.name, "model_model": model.model})
         new_records = super().create(vals_list)
-        updated = [record._register_hook() for record in new_records]
-        if any(updated):
-            modules.registry.Registry(self.env.cr.dbname).signal_changes()
+        if not self.env.context.get("install_module"):
+            updated = [record._register_hook() for record in new_records]
+            if any(updated):
+                modules.registry.Registry(self.env.cr.dbname).signal_changes()
         return new_records
 
     def write(self, vals):
@@ -245,7 +246,7 @@ class AuditlogRule(models.Model):
             model = self.env["ir.model"].sudo().browse(vals["model_id"])
             vals.update({"model_name": model.name, "model_model": model.model})
         res = super().write(vals)
-        if self._register_hook():
+        if not self.env.context.get("install_module") and self._register_hook():
             modules.registry.Registry(self.env.cr.dbname).signal_changes()
         return res
 

--- a/auditlog/tests/__init__.py
+++ b/auditlog/tests/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import test_auditlog
 from . import test_autovacuum
+from . import test_auditrule

--- a/auditlog/tests/test_auditrule.py
+++ b/auditlog/tests/test_auditrule.py
@@ -1,0 +1,41 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestAuditlogRule(TransactionCase):
+    def setUp(self):
+        super(TestAuditlogRule, self).setUp()
+        self.groups_model_id = self.env.ref("base.model_res_groups").id
+
+    def test_create_auto_subscribe(self):
+        """Link to quick view (action_id) should also be created with new rule"""
+        groups_rule = self.env["auditlog.rule"].create(
+            {
+                "name": "testrule for groups",
+                "model_id": self.groups_model_id,
+                "log_read": True,
+                "log_create": True,
+                "log_write": True,
+                "log_unlink": True,
+                "state": "subscribed",
+                "log_type": "full",
+            }
+        )
+        self.assertTrue(groups_rule.action_id)
+
+    def test_auto_subscribe_is_reentrant(self):
+        """Quick view link should not change"""
+        groups_rule = self.env["auditlog.rule"].create(
+            {
+                "name": "testrule for groups",
+                "model_id": self.groups_model_id,
+                "log_read": True,
+                "log_create": True,
+                "log_write": True,
+                "log_unlink": True,
+                "state": "subscribed",
+                "log_type": "full",
+            }
+        )
+        action_id = groups_rule.action_id
+        groups_rule.subscribe()
+        self.assertEqual(groups_rule.action_id, action_id)


### PR DESCRIPTION
Allow the auditlog rules be created in subscribed state, so no post init hooks need to be used to subscribe them