### PR TITLE
[FIX] align popover wrapper next to form field label

### DIFF
--- a/base_changeset/static/src/components/form_label.xml
+++ b/base_changeset/static/src/components/form_label.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-inherit="web.FormLabel" t-inherit-mode="extension">
-        <xpath expr="//label" position="after">
+        <xpath expr="//label" position="inside">
             <BaseChangesetPopoverWrapper record="props.record" fieldName="props.id" />
         </xpath>
     </t>


### PR DESCRIPTION
The popover wrapper moves to the next line after a label.
![image](https://github.com/EmesaDEV/server-tools/assets/16730148/1b98cf25-9206-4d2a-b6e0-acf1f20fd717)

This fix aligns popover wrapper next to form field label
![image](https://github.com/EmesaDEV/server-tools/assets/16730148/c4e17a61-b28f-48b2-ade1-f6612fdddd9b)
