### PR TITLE
Align badge next to the field

### DIFF
--- a/base_changeset/__manifest__.py
+++ b/base_changeset/__manifest__.py
@@ -23,7 +23,7 @@
     ],
     "assets": {
         "web.assets_backend": [
-            "base_changeset/static/src/components/form_label.*",
+            "base_changeset/static/src/components/form_field.*",
             "base_changeset/static/src/components/changeset_popover.*",
             "base_changeset/static/src/components/record.esm.js",
         ],

--- a/base_changeset/static/src/components/changeset_popover.esm.js
+++ b/base_changeset/static/src/components/changeset_popover.esm.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import {Component} from "@odoo/owl";
-import {FormLabel} from "@web/views/form/form_label";
+import {Field} from "@web/views/fields/field";
 import Popover from "web.Popover";
 
 export class BaseChangesetPopover extends Popover {
@@ -49,5 +49,5 @@ export class BaseChangesetPopoverWrapper extends Component {}
 BaseChangesetPopoverWrapper.components = {BaseChangesetPopover};
 BaseChangesetPopoverWrapper.template = "base_changeset.ChangesetPopoverWrapper";
 
-FormLabel.components = FormLabel.components || {};
-Object.assign(FormLabel.components, {BaseChangesetPopoverWrapper});
+Field.components = Field.components || {};
+Object.assign(Field.components, {BaseChangesetPopoverWrapper});

--- a/base_changeset/static/src/components/changeset_popover.scss
+++ b/base_changeset/static/src/components/changeset_popover.scss
@@ -1,6 +1,6 @@
 .o_changeset_popover {
     background-color: $o-view-background-color;
 }
-span.o_changeset_popover_wrapper > div {
-    display: inline;
+.o_wrap_input {
+    display: flex;
 }

--- a/base_changeset/static/src/components/form_field.xml
+++ b/base_changeset/static/src/components/form_field.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-    <t t-inherit="web.FormLabel" t-inherit-mode="extension">
-        <xpath expr="//label" position="inside">
+    <t t-inherit="web.Field" t-inherit-mode="extension">
+        <xpath expr="//div" position="after">
             <BaseChangesetPopoverWrapper record="props.record" fieldName="props.id" />
         </xpath>
     </t>


### PR DESCRIPTION
Address fields don't have label tags and they are bound to independent label "Address". Thus, all address fields changes badges are dropped as form label doesn't exist for them. 

Badge is aligned next to the field to solve this issue. 
<img width="446" alt="image" src="https://github.com/EmesaDEV/server-tools/assets/16730148/e54e578b-9ad6-486c-9a78-05bd30e8445f">


However, address fields still require some adjustments by inserting them into DIV so badge can be positioned next to the field.  
`<field name="street2" position="replace">
                <div class="o_row">
                     <field name="street2" placeholder="Street 2..." class="o_address_street"
                               attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
                </div>
            </field>`